### PR TITLE
Update to calibration sectors

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -163,7 +163,7 @@ class SiteCalibrationCalculator:
         return self.calibrationSectorDataframe['Offset'][directionBin] + self.calibrationSectorDataframe['Slope'][directionBin] * value
 
     def IECLimitCalculator(self):
-        if len(self.calibrationSectorDataframe.index) == 36:
+        if len(self.calibrationSectorDataframe.index) == 36 and 'vRatio' in self.calibrationSectorDataframe.columns:
             self.calibrationSectorDataframe['pctSpeedUp'] = (self.calibrationSectorDataframe['vRatio']-1)*100
             self.calibrationSectorDataframe['LowerLimit'] = pd.Series(data=np.roll(((self.calibrationSectorDataframe['vRatio']-1)*100)-2.0,1),index=self.calibrationSectorDataframe.index)
             self.calibrationSectorDataframe['UpperLimit'] = pd.Series(data=np.roll(((self.calibrationSectorDataframe['vRatio']-1)*100)+2.0,1),index=self.calibrationSectorDataframe.index)
@@ -398,8 +398,8 @@ class Dataset:
                         mask = (dataFrame[self.referenceDirectionBin] == direction)
                         dataCount = dataFrame[mask][self.referenceDirectionBin].count()
                         print "%0.2f\t%0.2f\t%0.2f\t%d" % (direction, config.calibrationSlopes[direction], config.calibrationOffsets[direction], dataCount)
-
-                return SiteCalibrationCalculator(config.calibrationSlopes, config.calibrationOffsets, self.referenceDirectionBin, config.referenceWindSpeed, actives = config.calibrationActives)
+                df = pd.DataFrame([config.calibrationSlopes, config.calibrationOffsets], index=['Slope','Offset']).T
+                return SiteCalibrationCalculator( self.referenceDirectionBin, config.referenceWindSpeed,df, actives = config.calibrationActives)
             else:
                 raise Exception("The specified slopes have different bin centres to that specified by siteCalibrationCenterOfFirstSector which is: {0}".format(config.siteCalibrationCenterOfFirstSector))
         else:

--- a/dataset.py
+++ b/dataset.py
@@ -139,62 +139,36 @@ class LeastSquares(CalibrationBase):
 
 class SiteCalibrationCalculator:
 
-    def __init__(self, slopes, offsets, directionBinColumn, valueColumn, counts = {}, actives = None,
-                       belowAbove = {}, sigA={}, sigB={}, cov={}, corr={}):
+    def __init__(self, directionBinColumn, valueColumn, calibrationSectorDataframe, actives = None):
 
-        self.belowAbove = belowAbove
+        self.calibrationSectorDataframe = calibrationSectorDataframe
         self.valueColumn = valueColumn
         self.directionBinColumn = directionBinColumn
 
         if actives != None:
+            self.calibrationSectorDataframe = self.calibrationSectorDataframe.loc[actives,:]
 
-            self.slopes = {}
-            self.offsets = {}
-            self.counts = {}
-            if sigA.keys() == slopes.keys():
-                uncertaintyInfo = True
-                self.sigA = {}
-                self.sigB = {}
-                self.cov = {}
-                self.corr = {}
-            else:
-                uncertaintyInfo = False
-
-            for direction in actives:
-
-                self.slopes[direction] = slopes[direction]
-                self.offsets[direction] = offsets[direction]
-                if uncertaintyInfo:
-                    self.sigA[direction] = sigA[direction]
-                    self.sigB[direction] = sigB[direction]
-                    self.cov[direction] = cov[direction]
-                    self.corr[direction] = corr[direction]
-
-                if direction in counts:
-                    #self.counts = counts[direction]
-                    self.counts[direction] = counts[direction]
-
-        else:
-
-            self.slopes = slopes
-            self.offsets = offsets
-            self.counts = counts
-            self.sigA = sigA
-            self.sigB = sigB
-            self.cov = cov
-            self.corr = corr
+        self.IECLimitCalculator()
 
     def turbineValue(self, row):
 
         directionBin = row[self.directionBinColumn]
 
-        if directionBin in self.slopes:
+        if directionBin in self.calibrationSectorDataframe.index:
             return self.calibrate(directionBin, row[self.valueColumn])
         else:
             return np.nan
 
     def calibrate(self, directionBin, value):
-        return self.offsets[directionBin] + self.slopes[directionBin] * value
+        return self.calibrationSectorDataframe['Offset'][directionBin] + self.calibrationSectorDataframe['Slope'][directionBin] * value
+
+    def IECLimitCalculator(self):
+        if len(self.calibrationSectorDataframe.index) == 36:
+            self.calibrationSectorDataframe['LowerLimit'] = pd.Series(data=np.roll(((self.calibrationSectorDataframe['vRatio']-1)*100)-2.0,1),index=self.calibrationSectorDataframe.index)
+            self.calibrationSectorDataframe['UpperLimit'] = pd.Series(data=np.roll(((self.calibrationSectorDataframe['vRatio']-1)*100)+2.0,1),index=self.calibrationSectorDataframe.index)
+            self.calibrationSectorDataframe['IECValid'] = np.logical_and(self.calibrationSectorDataframe['vRatio'] >  self.calibrationSectorDataframe['LowerLimit'], self.calibrationSectorDataframe['vRatio'] >  self.calibrationSectorDataframe['UpperLimit'])
+            print self.calibrationSectorDataframe[['LowerLimit','UpperLimit','IECValid']]
+        return True
 
 class ShearExponentCalculator:
 
@@ -472,12 +446,14 @@ class Dataset:
         sigB = {}
         cov  = {}
         corr  = {}
+        vRatio= {}
 
         for group in groups:
 
             directionBinCenter = group[0]
             sectorDataFrame = group[1].dropna()
 
+            # this would eb better as a dataframe!
             slopes[directionBinCenter] = calibration.slope(sectorDataFrame)
             intercepts[directionBinCenter] = calibration.intercept(sectorDataFrame, slopes[directionBinCenter])
             counts[directionBinCenter] = sectorDataFrame[valueColumn].count()
@@ -486,13 +462,17 @@ class Dataset:
             #cov[directionBinCenter]  = calibration.covariance(sectorDataFrame, calibration.x,calibration.y )
             cov[directionBinCenter]  = sigA[directionBinCenter]*sigB[directionBinCenter]*(-1.0 * sectorDataFrame[calibration.x].sum())/((counts[directionBinCenter] * (sectorDataFrame[calibration.x]**2).sum())**0.5)
             corr[directionBinCenter]  =sectorDataFrame[[calibration.x, calibration.y]].corr()[calibration.x][calibration.y]
+            vRatio[directionBinCenter] = (sectorDataFrame[calibration.x]/sectorDataFrame[calibration.y]).mean()# T_A1/R_A1
 
             if valueColumn == self.hubWindSpeedForTurbulence:
                 belowAbove[directionBinCenter] = (sectorDataFrame[sectorDataFrame[valueColumn] <= 8.0][valueColumn].count(),sectorDataFrame[sectorDataFrame[valueColumn] > 8.0][valueColumn].count())
 
-            print "{0}\t{1}\t{2}\t{3}".format(directionBinCenter, slopes[directionBinCenter], intercepts[directionBinCenter], counts[directionBinCenter])
+        calibrationSectorDataframe = pd.DataFrame([slopes,intercepts,counts, sigA, sigB, cov, corr, vRatio], ["Slope","Offset","Count","SigA","SigB","Cov","Corr","vRatio"] ).T
+        if len(belowAbove.keys()):
+            calibrationSectorDataframe['belowAbove'] = belowAbove.values()
+        print calibrationSectorDataframe
 
-        return SiteCalibrationCalculator(slopes, intercepts, self.referenceDirectionBin, valueColumn, counts = counts, belowAbove=belowAbove, sigA=sigA, sigB=sigB, cov=cov, corr=corr)
+        return SiteCalibrationCalculator(self.referenceDirectionBin, valueColumn, calibrationSectorDataframe)
 
     def isValidText(self, text):
         if text == None: return False

--- a/dataset.py
+++ b/dataset.py
@@ -164,10 +164,11 @@ class SiteCalibrationCalculator:
 
     def IECLimitCalculator(self):
         if len(self.calibrationSectorDataframe.index) == 36:
+            self.calibrationSectorDataframe['pctSpeedUp'] = (self.calibrationSectorDataframe['vRatio']-1)*100
             self.calibrationSectorDataframe['LowerLimit'] = pd.Series(data=np.roll(((self.calibrationSectorDataframe['vRatio']-1)*100)-2.0,1),index=self.calibrationSectorDataframe.index)
             self.calibrationSectorDataframe['UpperLimit'] = pd.Series(data=np.roll(((self.calibrationSectorDataframe['vRatio']-1)*100)+2.0,1),index=self.calibrationSectorDataframe.index)
             self.calibrationSectorDataframe['IECValid'] = np.logical_and(self.calibrationSectorDataframe['vRatio'] >  self.calibrationSectorDataframe['LowerLimit'], self.calibrationSectorDataframe['vRatio'] >  self.calibrationSectorDataframe['UpperLimit'])
-            print self.calibrationSectorDataframe[['LowerLimit','UpperLimit','IECValid']]
+            print self.calibrationSectorDataframe[['pctSpeedUp','LowerLimit','UpperLimit','IECValid']]
         return True
 
 class ShearExponentCalculator:
@@ -462,7 +463,7 @@ class Dataset:
             #cov[directionBinCenter]  = calibration.covariance(sectorDataFrame, calibration.x,calibration.y )
             cov[directionBinCenter]  = sigA[directionBinCenter]*sigB[directionBinCenter]*(-1.0 * sectorDataFrame[calibration.x].sum())/((counts[directionBinCenter] * (sectorDataFrame[calibration.x]**2).sum())**0.5)
             corr[directionBinCenter]  =sectorDataFrame[[calibration.x, calibration.y]].corr()[calibration.x][calibration.y]
-            vRatio[directionBinCenter] = (sectorDataFrame[calibration.x]/sectorDataFrame[calibration.y]).mean()# T_A1/R_A1
+            vRatio[directionBinCenter] = (sectorDataFrame[calibration.y]/sectorDataFrame[calibration.x]).mean()# T_A1/R_A1 - this is currently mean of all data
 
             if valueColumn == self.hubWindSpeedForTurbulence:
                 belowAbove[directionBinCenter] = (sectorDataFrame[sectorDataFrame[valueColumn] <= 8.0][valueColumn].count(),sectorDataFrame[sectorDataFrame[valueColumn] > 8.0][valueColumn].count())

--- a/reporting.py
+++ b/reporting.py
@@ -109,7 +109,7 @@ class report:
         startRow = 2
         col = -5
         for conf,calib in analysis.calibrations:
-            if calib.belowAbove != {}:
+            if 'belowAbove' in calib.calibrationSectorDataframe.columns :
                 belowAbove = True
             else:
                 belowAbove = False
@@ -130,15 +130,17 @@ class report:
 
 
             row+=1
-            for key in sorted(calib.slopes):
+            for key in sorted(calib.calibrationSectorDataframe.index):
                 sh.write(row,col,key, self.bold_style)
-                sh.write(row,col+1,calib.slopes[key], self.four_dp_style)
-                sh.write(row,col+2,calib.offsets[key], self.four_dp_style)
-                if key in calib.counts: sh.write(row,col+3,calib.counts[key], self.no_dp_style)
+                sh.write(row,col+1,calib.calibrationSectorDataframe['Slope'][key], self.four_dp_style)
+                sh.write(row,col+2,calib.calibrationSectorDataframe['Offset'][key], self.four_dp_style)
+                if 'Count' in calib.calibrationSectorDataframe.columns:
+                    sh.write(row,col+3,calib.calibrationSectorDataframe['Count'][key], self.no_dp_style)
                 if belowAbove:
-                    sh.write(row,col+4,calib.belowAbove[key][0], self.no_dp_style)
-                    sh.write(row,col+5,calib.belowAbove[key][1], self.no_dp_style)
-                    sh.write(row,col+6, "TRUE" if calib.belowAbove[key][0]*(analysis.timeStepInSeconds/3600.0) > 6.0 and  calib.belowAbove[key][1]*(analysis.timeStepInSeconds/3600.0) > 6.0 else "FALSE" , self.bold_style)
+                    ba = calib.calibrationSectorDataframe.loc[key,'belowAbove']
+                    sh.write(row,col+4,ba[0], self.no_dp_style)
+                    sh.write(row,col+5,ba[1], self.no_dp_style)
+                    sh.write(row,col+6, "TRUE" if ba[0]*(analysis.timeStepInSeconds/3600.0) > 6.0 and  ba[1]*(analysis.timeStepInSeconds/3600.0) > 6.0 else "FALSE" , self.bold_style)
                 row += 1
 
             if len(conf.calibrationFilters) > 0:


### PR DESCRIPTION
this is going to cause a problem with the resultsXMLexporter.py 

instead of SiteCalibrationCalculator.slopes it's now SiteCalibrationCalculator.calibrationSectorDataframe['Slope']

in total:

slopes -> SiteCalibrationCalculator.calibrationSectorDataframe['Slope']
counts -> SiteCalibrationCalculator.calibrationSectorDataframe['Count']
offsets -> SiteCalibrationCalculator.calibrationSectorDataframe['Offset']
sigA -> SiteCalibrationCalculator.calibrationSectorDataframe['SigA']
sigB -> SiteCalibrationCalculator.calibrationSectorDataframe['SigB']
cov -> SiteCalibrationCalculator.calibrationSectorDataframe['Cov']
corr -> SiteCalibrationCalculator.calibrationSectorDataframe['Corr']

also included are UpperLimit, LowerLimit and IEC valid. These can be used in the calibration report now.
